### PR TITLE
Enhance search capabilities in searchCode function

### DIFF
--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -73,6 +73,7 @@ export const SearchCodeArgsSchema = z.object({
   maxResults: z.number().optional(),
   includeHidden: z.boolean().optional(),
   contextLines: z.number().optional(),
+  fuzzy: z.boolean().optional(), // Pce82
 });
 
 // Edit tools schemas


### PR DESCRIPTION
Add support for fuzzy search in the `searchCode` function.

* **src/tools/search.ts**
  - Add a function to calculate Levenshtein distance.
  - Add `fuzzy` option to the `searchCode` function to enable or disable fuzzy search.
  - Modify the `searchCode` function to use custom fuzzy search logic when `fuzzy` option is enabled.
  - Apply fuzzy search logic to filter results based on Levenshtein distance when `fuzzy` option is enabled.

* **src/tools/schemas.ts**
  - Add `fuzzy` option to the `SearchCodeArgsSchema` to enable or disable fuzzy search.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wonderwhy-er/ClaudeDesktopCommander/pull/23?shareId=aece57dd-c5cf-4e70-b4a1-c8e66083b037).